### PR TITLE
feat(export report xlsx file name change):#59

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -12,7 +12,7 @@ from frappe.model import default_fields, optional_fields
 from frappe import _
 from six import string_types, StringIO
 from frappe.core.doctype.access_log.access_log import make_access_log
-from frappe.utils import cstr, format_duration
+from frappe.utils import cstr, format_duration,now
 from frappe.model.base_document import get_controller
 
 
@@ -325,7 +325,7 @@ def export_query():
 		from frappe.utils.xlsxutils import make_xlsx
 		xlsx_file = make_xlsx(data, doctype)
 
-		frappe.response['filename'] = title + '.xlsx'
+		frappe.response['filename'] = title +"_"+now()[:19] + '.xlsx'
 		frappe.response['filecontent'] = xlsx_file.getvalue()
 		frappe.response['type'] = 'binary'
 


### PR DESCRIPTION
Base Branch :Version 13
Created this PR against issue#59 created on leadergroup repository
Feature : While exporting doctype in reportview when xlsx file type is selected  downloaded fille name will be updated with current date and current  time   (Example file name : Lead_2021-12-03_09_10_31.xlsx)
This feature will fix the problem of replacing file popup while downloading  

Sample screenshot

![Screenshot from 2021-12-03 11-49-39](https://user-images.githubusercontent.com/42955369/144555832-35100e29-c75d-412e-afc3-0793d3c45c52.png)
