### PR TITLE
fix:While deleting submitted doctype: Validation msg Cancel link redi…

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -259,11 +259,9 @@ def check_permission_and_not_submitted(doc):
 	# check if submitted
 	if doc.docstatus == 1:
 		frappe.msgprint(
-			_("{0} {1}: Submitted Record cannot be deleted. You must {2} Cancel {3} it first.").format(
+			_("{0} {1}: Submitted Record cannot be deleted. You must Cancel it first.").format(
 				_(doc.doctype),
 				doc.name,
-				"<a href='https://docs.erpnext.com//docs/user/manual/en/setting-up/articles/delete-submitted-document' target='_blank'>",
-				"</a>",
 			),
 			raise_exception=True,
 		)


### PR DESCRIPTION
Issue : https://github.com/leadergroupsaudi/foxerp/issues/324

While deleting submitted doctype, In the validation message Cancel link redirect to erpnext documentation page issue
Removed the erpnext hyperlink 

Screenshot:
![Screenshot from 2023-11-09 12-59-46](https://github.com/leadergroupsaudi/frappe/assets/120644558/2451cc6a-86ee-4911-893e-070c48e8a795)

