### PR TITLE
 file upload validation

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -189,14 +189,12 @@ def upload_file():
 	frappe.local.uploaded_file = content
 	frappe.local.uploaded_filename = filename
 
-	if content is not None and (
-		frappe.session.user == "Guest" or (user and not user.has_desk_access())
-	):
-		import mimetypes
+	
+	import mimetypes
 
-		filetype = mimetypes.guess_type(filename)[0]
-		if filetype not in ALLOWED_MIMETYPES:
-			frappe.throw(_("You can only upload JPG, PNG, PDF, TXT or Microsoft documents."))
+	filetype = mimetypes.guess_type(filename)[0]
+	if filetype not in ALLOWED_MIMETYPES:
+		frappe.throw(_("You can only upload JPG, PNG, PDF, TXT or Microsoft documents."))
 
 	if method:
 		method = frappe.get_attr(method)

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -936,10 +936,19 @@ Object.assign(frappe.utils, {
 		}
 	},
 	get_decoded_string(dataURI) {
+		let ALLOWED_MIMETYPES = [
+			"data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+			"data:text/csv"
+		]
 		// decodes base64 to string
 		let parts = dataURI.split(',');
 		const encoded_data = parts[1];
 		let decoded = atob(encoded_data);
+
+		
+		if(! ALLOWED_MIMETYPES.includes(parts[0].split(";")[0])){
+			frappe.throw("You can only upload CSV or XLSX documents.")
+		} 
 		try {
 			const escaped = escape(decoded);
 			decoded = decodeURIComponent(escaped);


### PR DESCRIPTION
##Issue https://github.com/leadergroupsaudi/foxerp-epm/issues/478


## Doctype
    for attachment upload, allow only word, excel, pdf and image formats only. blocking the other extension files.

![image](https://github.com/leadergroupsaudi/frappe/assets/88370162/56e76e80-177b-4b6c-8bfa-f22c34ac1ed1)


## Child Table
    for bulk upload allow only XLSX and CSV files. blocking the other extension files.

![image](https://github.com/leadergroupsaudi/frappe/assets/88370162/9f6e96b6-36ff-4102-8c71-4409bc6bfcee)
