### PR TITLE
fix:API response Hide the error trackback

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -64,7 +64,11 @@ def execute_cmd(cmd, from_async=False):
 	try:
 		method = get_attr(cmd)
 	except Exception as e:
-		frappe.throw(_("Failed to get method for command {0} with {1}").format(cmd, e))
+		show_traceback = frappe.db.get_single_value("System Settings","show_traceback_error_to_the_developer",cache=True)
+		if show_traceback:
+			frappe.throw(_("Failed to get method for command {0} with {1}").format(cmd, e))
+		else:
+			return "Internal Server Error"
 
 	if from_async:
 		method = method.queue


### PR DESCRIPTION
Issue https://github.com/leadergroupsaudi/foxerp/issues/376
**In API response Hide the error trackback and display as Internal Server Error**
System Settings doctype added new fields: Show Traceback Error to the Developer
![Screenshot from 2024-01-22 12-45-08](https://github.com/frappe/frappe/assets/120644558/3e0f68ce-24ba-4a0b-83c1-5ce9fa626574)

Show Traceback Error to the Developer, If the field is enabled then show the full traceback error to the Developer  
![Screenshot from 2024-01-22 12-46-15](https://github.com/frappe/frappe/assets/120644558/4678e7c7-cdef-4a05-9fab-d7abffb1a052)

Show Traceback Error to the Developer, If the field is disabled then show the "Internal Server Error" 
![Screenshot from 2024-01-22 12-46-31](https://github.com/frappe/frappe/assets/120644558/8678c7c0-6cb0-42f9-8d9a-3998e224a2d6)
