### PR TITLE
fix:API response Hide the error trackback

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -49,6 +49,7 @@
   "strip_exif_metadata_from_uploaded_images",
   "allow_older_web_view_links",
   "apply_perm_level_on_api_calls",
+  "show_traceback_error_to_the_developer",
   "password_settings",
   "logout_on_password_reset",
   "force_user_to_reset_password",
@@ -436,11 +437,11 @@
    "label": "Include Web View Link in Email"
   },
   {
-    "collapsible": 1,
-    "fieldname": "prepared_report_section",
-    "fieldtype": "Section Break",
-    "label": "Reports"
-   },
+   "collapsible": 1,
+   "fieldname": "prepared_report_section",
+   "fieldtype": "Section Break",
+   "label": "Reports"
+  },
   {
    "default": "Frappe",
    "description": "The application name will be used in the Login page.",
@@ -592,12 +593,18 @@
   {
    "fieldname": "column_break_uqma",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_traceback_error_to_the_developer",
+   "fieldtype": "Check",
+   "label": "Show Traceback Error to the Developer"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2023-10-17 16:12:28.145496",
+ "modified": "2024-02-01 12:53:32.534794",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -73,7 +73,11 @@ def execute_cmd(cmd, from_async=False):
 	try:
 		method = get_attr(cmd)
 	except Exception as e:
-		frappe.throw(_("Failed to get method for command {0} with {1}").format(cmd, e))
+		show_traceback = frappe.db.get_single_value("System Settings","show_traceback_error_to_the_developer",cache=True)
+		if show_traceback:
+			frappe.throw(_("Failed to get method for command {0} with {1}").format(cmd, e))
+		else:
+			return "Internal Server Error"
 
 	if from_async:
 		method = method.queue


### PR DESCRIPTION
## Issue https://github.com/leadergroupsaudi/foxerp/issues/376

### In API response Hide the error trackback and display as Internal Server Error
System Settings doctype added new fields: Show Traceback Error to the Developer

![image](https://github.com/leadergroupsaudi/frappe/assets/88370162/f344b5a6-e04f-4452-8eeb-aacf82adca77)

`if Show Traceback Error to the Developer == True`

![image](https://github.com/leadergroupsaudi/frappe/assets/88370162/46b1533f-e072-4f38-a5d3-bdf4858c7644)

`if Show Traceback Error to the Developer == False`

![image](https://github.com/leadergroupsaudi/frappe/assets/88370162/b3c5e843-0d64-4e84-adb8-835d7132f671)
