### PR TITLE
fix: file upload validation

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -219,12 +219,11 @@ def upload_file():
 	frappe.local.uploaded_file = content
 	frappe.local.uploaded_filename = filename
 
-	if content is not None and (
-		frappe.session.user == "Guest" or (user and not user.has_desk_access())
-	):
-		filetype = guess_type(filename)[0]
-		if filetype not in ALLOWED_MIMETYPES:
-			frappe.throw(_("You can only upload JPG, PNG, PDF, TXT or Microsoft documents."))
+	import mimetypes
+
+	filetype = mimetypes.guess_type(filename)[0]
+	if filetype not in ALLOWED_MIMETYPES:
+		frappe.throw(_("You can only upload JPG, PNG, PDF, TXT or Microsoft documents."))
 
 	if method:
 		method = frappe.get_attr(method)


### PR DESCRIPTION
**for attachment upload, allow only word, excel, pdf and image formats only. blocking the other extension files.**

![Screenshot from 2024-02-01 15-42-12](https://github.com/leadergroupsaudi/frappe/assets/126647733/d48a568e-44ce-43fa-98be-f298bbfc50a5)
