### PR TITLE
fix:while deleting submitted doctype - validation message cancel link…

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -226,11 +226,9 @@ def check_permission_and_not_submitted(doc):
 	# check if submitted
 	if doc.docstatus.is_submitted():
 		frappe.msgprint(
-			_("{0} {1}: Submitted Record cannot be deleted. You must {2} Cancel {3} it first.").format(
+			_("{0} {1}: Submitted Record cannot be deleted. You must Cancel it first.").format(
 				_(doc.doctype),
 				doc.name,
-				"<a href='https://docs.erpnext.com//docs/user/manual/en/setting-up/articles/delete-submitted-document' target='_blank'>",
-				"</a>",
 			),
 			raise_exception=True,
 		)


### PR DESCRIPTION
Issue : https://github.com/leadergroupsaudi/foxerp/issues/324

While deleting submitted doctype, In the validation message Cancel link redirect to erpnext documentation page issue
Removed the erpnext hyperlink

Screenshot:
![Screenshot from 2024-02-02 15-14-32](https://github.com/leadergroupsaudi/frappe/assets/157521224/b081cbed-9931-42a0-a4b0-700cf9f08868)
