### PR TITLE
fix:[LIG-76] Attachments in ERP

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -219,11 +219,12 @@ def upload_file():
 	frappe.local.uploaded_file = content
 	frappe.local.uploaded_filename = filename
 
-	import mimetypes
-
-	filetype = mimetypes.guess_type(filename)[0]
-	if filetype not in ALLOWED_MIMETYPES:
-		frappe.throw(_("You can only upload JPG, PNG, PDF, TXT or Microsoft documents."))
+	if content is not None and (
+		frappe.session.user == "Guest" or (user and not user.has_desk_access())
+	):
+		filetype = guess_type(filename)[0]
+		if filetype not in ALLOWED_MIMETYPES:
+			frappe.throw(_("You can only upload JPG, PNG, PDF, TXT or Microsoft documents."))
 
 	if method:
 		method = frappe.get_attr(method)


### PR DESCRIPTION
JIRA issue: [LIG-76] https://leaderlelab.atlassian.net/browse/LIG-76
The Removed Code is for restriction of Files Attachment in other format, it only allow to attach file format in JPG, PNG, PDF, TXT or Microsoft documents. So this is required only in EPM site version -13. 
In Version 14 the code is removed and it allow to attach image in other formats too.

Screenshot:
![image](https://github.com/leadergroupsaudi/frappe/assets/155341882/c6d19d87-1083-43bb-8553-9a67febde4ca)

 